### PR TITLE
add yarn.lock file to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN npm config set '@bit:registry' https://node.bit.dev
 
 COPY .npmrc ./
 COPY package*.json ./
+COPY yarn.lock ./
 RUN yarn install
 
 COPY . .


### PR DESCRIPTION
It was missing before giving some warning during the build that there is no lockfile